### PR TITLE
Update .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -24,6 +24,7 @@ version: "2"
 plugins:
   rubocop:
     enabled: true
+    channel: rubocop-0-60
   # coffeelint:
   #   enabled: true
   scss-lint:


### PR DESCRIPTION
This PR enables Code Climate's Rubocop 0.63 channel, as documented [here](https://docs.codeclimate.com/docs/rubocop#section-using-rubocop-s-newer-versions). This should support the use of TargetRubyVersion: 2.6, and allow your analysis to complete successfully.