### PR TITLE
Update text shown after submitting a data request

### DIFF
--- a/app/views/data_requests/submitted.html.haml
+++ b/app/views/data_requests/submitted.html.haml
@@ -15,22 +15,18 @@
   %p
     Once your data request is approved, you will be able to download data from
     the datasets you requested.
+  
+  %p
+    %strong
+      Please allow up to two (2) weeks for your request to be reviewed by the 
+      NSRR team.
 
   %p
-    New to the NSRR? Get started with our
-    = link_to "Where to Start", showcase_show_path("where-to-start")
-    guide.
-
-  %p
-    Learn how to download data using the NSRR gem:
-    = link_to "NSRR Demo", demo_path
-
-  %p
-    Also, post any questions on the
+    If you need help, please post questions on the
     = link_to "forum", topics_path
     or contact us directly at
     = mail_to ENV["support_email"]
-    if you need any help!
+    .
 
   %p Welcome aboard!
 


### PR DESCRIPTION
Trying to add a clearer note to users that data requests take a couple weeks to be reviewed (discussed with PS). Removed some of the extraneous text bits.

Note that the bolded text would be confusing for "immediate access" datasets, but there aren't any datasets of this type (yet). A fancier idea might be to have this text customizable per dataset, but that's another conversation.